### PR TITLE
Implement support for JSON object/array responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
  "env_logger",
  "log",
  "maud",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ actix-web = "4"
 env_logger = "0.11.8"
 log = "0.4.29"
 maud = { version = "0.27.0", features = ["actix-web"] }
+serde_json = "1.0.149"

--- a/src/kv_store.rs
+++ b/src/kv_store.rs
@@ -1,6 +1,8 @@
+use actix_web::http::header::ContentType;
 use std::{collections::HashMap, sync::Mutex};
 
 use actix_web::{HttpRequest, HttpResponse, Responder, get, http::header::HeaderValue, post, web};
+use serde_json::Value;
 
 pub type KeyValueStore = Mutex<HashMap<String, HashMap<String, String>>>;
 
@@ -24,15 +26,30 @@ pub async fn get_kv(
 
     let store = store.lock().unwrap();
 
+    // check if context exists
     let Some(inner) = store.get(context) else {
-        // no context found, means key not found
         return HttpResponse::NotFound().body("Key not found");
     };
 
-    match inner.get(&key.clone()) {
-        // todo return the value as a string
-        Some(value) => HttpResponse::Ok().json(value),
-        None => HttpResponse::NotFound().body("Key not found"),
+    // check if key exists
+    let Some(value) = inner.get(&key.clone()) else {
+        return HttpResponse::NotFound().body("Key not found");
+    };
+
+    // check if value is json, else return as plaintext
+    let Ok(json) = serde_json::from_str::<Value>(value) else {
+        return HttpResponse::Ok()
+            .content_type(ContentType::plaintext())
+            .body(value.clone());
+    };
+
+    // return json objects and arrays as json, else plaintext (number, string, boolean)
+    match json {
+        Value::Object(obj) => HttpResponse::Ok().json(obj),
+        Value::Array(arr) => HttpResponse::Ok().json(arr),
+        _ => HttpResponse::Ok()
+            .content_type(ContentType::plaintext())
+            .body(value.clone()),
     }
 }
 

--- a/tests/kv_json_object.hurl
+++ b/tests/kv_json_object.hurl
@@ -1,18 +1,17 @@
-GET {{target}}/kv/key1
+GET {{target}}/kv/test-json-object
 HTTP 404
 
-POST {{target}}/kv/key1
+POST {{target}}/kv/test-json-object
 {
     "hello": "world"
 }
 HTTP 200
 
-
-GET {{target}}/kv/key1
+GET {{target}}/kv/test-json-object
 HTTP 200
 
 [Asserts]
 body contains "world"
 # todo make this run, it should be possible to select this
 # the problem is that the response is not json but a json string.
-#jsonpath "$.hello" == "world"
+jsonpath "$.hello" == "world"

--- a/tests/kv_plaintext_number.hurl
+++ b/tests/kv_plaintext_number.hurl
@@ -1,0 +1,13 @@
+GET {{target}}/kv/test-plaintext-number
+HTTP 404
+
+POST {{target}}/kv/test-plaintext-number
+`123`
+HTTP 200
+
+GET {{target}}/kv/test-plaintext-number
+HTTP 200
+
+[Asserts]
+header "Content-Type" contains "text/plain"
+body == "123"

--- a/tests/kv_plaintext_string.hurl
+++ b/tests/kv_plaintext_string.hurl
@@ -1,0 +1,13 @@
+GET {{target}}/kv/test-plaintext-string
+HTTP 404
+
+POST {{target}}/kv/test-plaintext-string
+`Hello, world!`
+HTTP 200
+
+GET {{target}}/kv/test-plaintext-string
+HTTP 200
+
+[Asserts]
+header "Content-Type" contains "text/plain"
+body == "Hello, world!"


### PR DESCRIPTION
Responds with `application/json` if the value is a valus JSON array or object, otherwise respond with `text/plain`.

Adds dependency `serde_json` to parse JSON.

Fixes #1